### PR TITLE
Quick Fix for Lower Value not set when Min Range is specified first...

### DIFF
--- a/NMRangeSlider/NMRangeSlider.m
+++ b/NMRangeSlider/NMRangeSlider.m
@@ -136,6 +136,13 @@
             [self setUpperValue:upperValue];
         }
         
+        // TMP HACK (HKS): Do again in case the lack of upper value + minRange messed it up
+        if(!isnan(lowerValue))
+        {
+            [self setLowerValue:lowerValue];
+        }
+
+        
     };
     
     if(animated)


### PR DESCRIPTION
In the setters, lowerValue depends on upperValue when minRange is set.  If upperValue is still 0 then this causes lowerValue to not be set.  

This commit is a quick fix (hack) that just calls setLowerValue a second time in the setLowerValue:upperValue method.  It still doesn't solve the problem of the client using the properties to initialise the lower and upper values.  

A better fix might be to have lower/upperValue initialise to -/+FLT_MAX or have lower value only adjust for minRange if (upperValue != some-pre-decided-init)...it's probably worth a bit more thought...

Thx for the component.  I've given it 5 stars on CocoaControls :)
