### PR TITLE
Accessibility Labels for the handles of NMRangeSlider

### DIFF
--- a/NMRangeSlider/NMRangeSlider.h
+++ b/NMRangeSlider/NMRangeSlider.h
@@ -69,4 +69,8 @@
 
 - (void) setLowerValue:(float) lowerValue upperValue:(float) upperValue animated:(BOOL)animated;
 
+//Setting the accessibility
+- (void)setAccessibilityLabelOfLowerHandle:(NSString*)lowerHandleLabel
+                            andUpperHandle:(NSString*)upperHandleLabel;
+
 @end

--- a/NMRangeSlider/NMRangeSlider.m
+++ b/NMRangeSlider/NMRangeSlider.m
@@ -508,4 +508,17 @@
     [self sendActionsForControlEvents:UIControlEventValueChanged];
 }
 
+
+#pragma mark -
+#pragma mark Accessibility
+
+- (void)setAccessibilityLabelOfLowerHandle:(NSString*)lowerHandleLabel
+                            andUpperHandle:(NSString*)upperHandleLabel {
+    [self.lowerHandle setIsAccessibilityElement:YES];
+    [self.lowerHandle setAccessibilityLabel:lowerHandleLabel];
+    
+    [self.upperHandle setIsAccessibilityElement:YES];
+    [self.upperHandle setAccessibilityLabel:upperHandleLabel];
+}
+
 @end


### PR DESCRIPTION
Signed-off-by: rkretzschmar rene.kretzschmar@gmx.com

Hi muZZkat,

great control! 

We use it in our project, but we need it to be accessible for blind people, too. And since those handles are "private" and we could not create a category for our accessibility injection - I just forked your github repo and patched your code accordingly. Maybe our change could be useful for others, as well.

Thanks and best regards,
Rene
