### PR TITLE
Added lowerMaximumValue and upperMinimumValue

### DIFF
--- a/NMRangeSlider/NMRangeSlider.h
+++ b/NMRangeSlider/NMRangeSlider.h
@@ -43,6 +43,12 @@
 // center location for the upper handle control
 @property(readonly, nonatomic) CGPoint upperCenter;
 
+// maximum value for left thumb
+@property(assign, nonatomic) float lowerMaximumValue;
+
+// minimum value for right thumb
+@property(assign, nonatomic) float upperMinimumValue;
+
 
 // Images, these should be set before the control is displayed.
 // If they are not set, then the default images are used.

--- a/NMRangeSlider/NMRangeSlider.m
+++ b/NMRangeSlider/NMRangeSlider.m
@@ -65,6 +65,9 @@
     
     _lowerValue = 0.0;
     _upperValue = 1.0;
+    
+    _lowerMaximumValue = NAN;
+    _upperMinimumValue = NAN;
 }
 
 // ------------------------------------------------------------------------------------------------------
@@ -92,6 +95,11 @@
     }
     
     value = MAX(value, _minimumValue);
+    
+    if (!isnan(_lowerMaximumValue)) {
+        value = MIN(value, _lowerMaximumValue);
+    }
+    
     value = MIN(value, _upperValue - _minimumRange);
     
     _lowerValue = value;
@@ -109,6 +117,11 @@
     }
 
     value = MIN(value, _maximumValue);
+    
+    if (!isnan(_upperMinimumValue)) {
+        value = MAX(value, _upperMinimumValue);
+    }
+    
     value = MAX(value, _lowerValue+_minimumRange);
     
     _upperValue = value;


### PR DESCRIPTION
I added two properties to allow a 'centered' minimum value.
I needed a slider to select a time range in x days in the past and x days in the future. So one could set lowerMaximumValue and upperMinimumValue to 50%, this would represent today. 0% would be in the past and 100% in the future.
