### PR TITLE
Handle images are misaligned and "fuzzy"

### DIFF
--- a/NMRangeSlider/NMRangeSlider.m
+++ b/NMRangeSlider/NMRangeSlider.m
@@ -329,7 +329,7 @@
     float xValue = ((self.bounds.size.width-thumbRect.size.width)*((value - _minimumValue) / (_maximumValue - _minimumValue)));
     thumbRect.origin = CGPointMake(xValue, (self.bounds.size.height/2.0f) - (thumbRect.size.height/2.0f));
     
-    return thumbRect;
+    return CGRectIntegral(thumbRect);
 
 }
 


### PR DESCRIPTION
Fixes fuzzy handle images due to placement of the handles on a sub-pixel origin. Will not affect the control's value which is determined by the touch position.

This problem was apparent while dragging and also after dragging unless the slider snapped to an integer pixel value. The image shows what "fuzzy" means in this case. The dark top edge of the slider was gone which is what caught my eye. Shown with the iOS Simulator's _Color Misaligned Images_ option.

![slider-rendering](https://f.cloud.github.com/assets/507058/149942/c939e08e-753e-11e2-9f2e-0e97d2f882c7.png)
