### PR TITLE
Adds -intrinsicContentSize for AutoLayout

### DIFF
--- a/NMRangeSlider/NMRangeSlider.m
+++ b/NMRangeSlider/NMRangeSlider.m
@@ -383,6 +383,10 @@
     self.upperHandle.frame = [self thumbRectForValue:_upperValue image:self.upperHandleImageNormal];
 }
 
+- (CGSize)intrinsicContentSize
+{
+   return CGSizeMake(UIViewNoIntrinsicMetric, MAX(self.lowerHandleImageNormal.size.height, self.upperHandleImageNormal.size.height));
+}
 
 // ------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Implemented -intrinsicContentSize for proper control sizing with AutoLayout.

This change specifies a minimum height for the control so that it can be used with AutoLayout without specifying dimensions in advance. The exact value can be tweaked since this would result in a very tight fit, but the value provided (the height of the sliders) should be the absolute minimum height required. Prior to this fix the control would appear full-size but the touchable area could be too small to use.
