### PR TITLE
expose default handle widths

### DIFF
--- a/NMRangeSlider/NMRangeSlider.h
+++ b/NMRangeSlider/NMRangeSlider.h
@@ -53,6 +53,9 @@
 @property (assign, nonatomic) BOOL lowerHandleHidden;
 @property (assign, nonatomic) BOOL upperHandleHidden;
 
+@property (assign, nonatomic) float lowerHandleHiddenWidth;
+@property (assign, nonatomic) float upperHandleHiddenWidth;
+
 // Images, these should be set before the control is displayed.
 // If they are not set, then the default images are used.
 // eg viewDidLoad

--- a/NMRangeSlider/NMRangeSlider.m
+++ b/NMRangeSlider/NMRangeSlider.m
@@ -95,6 +95,9 @@ NSUInteger DeviceSystemMajorVersion() {
     _upperMinimumValue = NAN;
     _upperHandleHidden = NO;
     _lowerHandleHidden = NO;
+    
+    _lowerHandleHiddenWidth = 2.0f;
+    _upperHandleHiddenWidth = 2.0f;
 }
 
 // ------------------------------------------------------------------------------------------------------
@@ -413,8 +416,8 @@ NSUInteger DeviceSystemMajorVersion() {
         retValue.size.height=self.bounds.size.height;
     }
     
-    float lowerHandleWidth = _lowerHandleHidden ? 2.0f : _lowerHandle.frame.size.width;
-    float upperHandleWidth = _upperHandleHidden ? 2.0f : _upperHandle.frame.size.width;
+    float lowerHandleWidth = _lowerHandleHidden ? _lowerHandleHiddenWidth : _lowerHandle.frame.size.width;
+    float upperHandleWidth = _upperHandleHidden ? _upperHandleHiddenWidth : _upperHandle.frame.size.width;
     
     float xLowerValue = ((self.bounds.size.width - lowerHandleWidth) * (_lowerValue - _minimumValue) / (_maximumValue - _minimumValue))+(lowerHandleWidth/2.0f);
     float xUpperValue = ((self.bounds.size.width - upperHandleWidth) * (_upperValue - _minimumValue) / (_maximumValue - _minimumValue))+(upperHandleWidth/2.0f);


### PR DESCRIPTION
Exposed the default handle widths when upper or lower are hidden.

Currently the default value is 2.0.

When using a rounded inset image the track bar can become skewed.  Allowing these values to be adjusted will prevent this skewing.
