### PR TITLE
Fixed positions for slider labels

### DIFF
--- a/NMRangeSlider-Demo/NMDemoTVC.m
+++ b/NMRangeSlider-Demo/NMDemoTVC.m
@@ -21,6 +21,10 @@
 #pragma mark -
 #pragma mark - View LifeCycle
 
+- (void)scrollViewDidScroll: (UIScrollView*)scroll { // only use this if you are using a Point Feedback slider
+    [self updateSliderLabels];
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];

--- a/NMRangeSlider.xcodeproj/project.xcworkspace/xcshareddata/NMRangeSlider.xccheckout
+++ b/NMRangeSlider.xcodeproj/project.xcworkspace/xcshareddata/NMRangeSlider.xccheckout
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
+	<key>IDESourceControlProjectIdentifier</key>
+	<string>A6C7706C-8655-48C6-ABAD-2A8C8A6D6B37</string>
+	<key>IDESourceControlProjectName</key>
+	<string>NMRangeSlider</string>
+	<key>IDESourceControlProjectOriginsDictionary</key>
+	<dict>
+		<key>E61B89F65BCF5E1B0B6C39A6E0758DD579FB3D88</key>
+		<string>https://github.com/rfogar2/NMRangeSlider.git</string>
+	</dict>
+	<key>IDESourceControlProjectPath</key>
+	<string>NMRangeSlider.xcodeproj</string>
+	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
+	<dict>
+		<key>E61B89F65BCF5E1B0B6C39A6E0758DD579FB3D88</key>
+		<string>../..</string>
+	</dict>
+	<key>IDESourceControlProjectURL</key>
+	<string>https://github.com/rfogar2/NMRangeSlider.git</string>
+	<key>IDESourceControlProjectVersion</key>
+	<integer>111</integer>
+	<key>IDESourceControlProjectWCCIdentifier</key>
+	<string>E61B89F65BCF5E1B0B6C39A6E0758DD579FB3D88</string>
+	<key>IDESourceControlProjectWCConfigurations</key>
+	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>E61B89F65BCF5E1B0B6C39A6E0758DD579FB3D88</string>
+			<key>IDESourceControlWCCName</key>
+			<string>NMRangeSlider</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Previously, if a label slider value was changed when the label slider was not in the screen when current viewController was loaded (i.e. you had to scroll to get to it) the position of the slider label did not move to the correct position. 
