### PR TITLE
Create bundle

### DIFF
--- a/NMRangeSlider.podspec
+++ b/NMRangeSlider.podspec
@@ -10,5 +10,5 @@ Pod::Spec.new do |s|
   s.platform            = :ios
   s.source_files        = 'NMRangeSlider/*.{h,m}'
   s.requires_arc        = true
-  s.resources           = "NMRangeSlider/DefaultTheme/*.png", "NMRangeSlider/DefaultTheme7/*.png", "NMRangeSlider/MetalTheme/*.png"
+  s.ios.resource_bundle = {'NMRangeSlider' => ["NMRangeSlider/DefaultTheme/*.png", "NMRangeSlider/DefaultTheme7/*.png"    , "NMRangeSlider/MetalTheme/*.png"]}
 end


### PR DESCRIPTION
In NMRangeSlider.m, images are loaded from a bundle named NMRangeSlider, but it doesn't has such a bundle so I create NMRangeSlider bundle.
It will be helpful for Swift projects.
