### PR TITLE
Fixed bug when setting lower and upper bounds in a specific order

### DIFF
--- a/NMRangeSlider/NMRangeSlider.m
+++ b/NMRangeSlider/NMRangeSlider.m
@@ -136,7 +136,9 @@ NSUInteger DeviceSystemMajorVersion() {
         value = MIN(value, _lowerMaximumValue);
     }
     
-    value = MIN(value, _upperValue - _minimumRange);
+    if (MIN(value, _upperValue - _minimumRange) >= _minimumValue) {
+        value = MIN(value, _upperValue - _minimumRange);
+    }
     
     _lowerValue = value;
     


### PR DESCRIPTION
I've added a quick if-statement to detect if the lower bounds will be less than _minimumValue as a result of setting lowerValue before upperValue.
